### PR TITLE
show: use charset=utf-8 in html

### DIFF
--- a/show.go
+++ b/show.go
@@ -211,6 +211,7 @@ var statsTmpl = template.Must(template.New("").Funcs(map[string]interface{}{
 	"timeToJS": timeToJS,
 }).Parse(`<html>
   <head>
+	<meta charset="utf-8">
 	<style>
 		.description {
 			font-family: Roboto;


### PR DESCRIPTION
this will prevents browsers to incorrectly display utf entities, which
can be present in the title names of windows.