### PR TITLE
add watch command

### DIFF
--- a/cmd/thyme/main.go
+++ b/cmd/thyme/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/sourcegraph/thyme"
@@ -17,11 +18,41 @@ func init() {
 	if _, err := CLI.AddCommand("track", "", "record current windows", &trackCmd); err != nil {
 		log.Fatal(err)
 	}
+	if _, err := CLI.AddCommand("watch", "", "record current windows at regular intervals (default 30s)", &watchCmd); err != nil {
+		log.Fatal(err)
+	}
 	if _, err := CLI.AddCommand("show", "", "visualize data", &showCmd); err != nil {
 		log.Fatal(err)
 	}
 	if _, err := CLI.AddCommand("dep", "", "external dependencies that need to be installed", &depCmd); err != nil {
 		log.Fatal(err)
+	}
+}
+
+// WatchCmd is the subcommand that tracks application usage at regular intervals.
+type WatchCmd struct {
+	// The track command is a subset of the watch command
+	TrackCmd
+	Interval int64 `long:"interval" short:"n" description:"update interval (default 30 seconds)"`
+}
+
+var watchCmd WatchCmd
+
+func (c *WatchCmd) Execute(args []string) error {
+	var interval time.Duration
+	if c.Interval <= 0 {
+		// Set default interval
+		interval = 30 * time.Second
+	} else {
+		interval = time.Duration(c.Interval) * time.Second
+	}
+
+	// Loop until the user aborts the command
+	for {
+		c.TrackCmd.Execute(args)
+
+		// Sleep for a while until the next time we should track active windows
+		time.Sleep(interval)
 	}
 }
 


### PR DESCRIPTION
A common use case for 'thyme' is to record the active windows at regular intervals.
To make this easier, the command 'watch' can now be used instead of 'track'.

$ thyme watch -n <value> -o thyme.json

should be equivalent to

$ watch -n <value> thyme track -o thyme.json
or
$ while true; do thyme track -o thyme.json; sleep <value>s; done;

but is also usable on systems that do not have 'watch' installed and easier
to use than a shell loop.

If no interval is specified (-n or --interval) then it defaults to 30 seconds.

This was originally suggested by @keegancsmith.