### PR TITLE
stop assuming always active window, fixes #15

### DIFF
--- a/show.go
+++ b/show.go
@@ -44,7 +44,9 @@ func NewAggTime(stream *Stream, labelFunc func(*Window) string) *AggTime {
 			windows[win.ID] = win
 		}
 
-		active.Plus(labelFunc(windows[snap.Active]), 1)
+		if win := windows[snap.Active]; win != nil {
+			active.Plus(labelFunc(windows[snap.Active]), 1)
+		}
 		for _, v := range snap.Visible {
 			visible.Plus(labelFunc(windows[v]), 1)
 		}
@@ -138,17 +140,20 @@ func NewTimeline(stream *Stream, labelFunc func(*Window) string) *Timeline {
 		}
 
 		{
-			win := windows[snap.Active]
-			winLabel := labelFunc(win)
-			if lastActive != nil && lastActive.Label == winLabel {
-				lastActive.End = snap.Time
-			} else {
-				if lastActive != nil {
+			if win := windows[snap.Active]; win != nil {
+				winLabel := labelFunc(win)
+				if lastActive != nil && lastActive.Label == winLabel {
 					lastActive.End = snap.Time
+				} else {
+					if lastActive != nil {
+						lastActive.End = snap.Time
+					}
+					newRange := &Range{Label: winLabel, Start: snap.Time, End: snap.Time}
+					active = append(active, newRange)
+					lastActive = newRange
 				}
-				newRange := &Range{Label: winLabel, Start: snap.Time, End: snap.Time}
-				active = append(active, newRange)
-				lastActive = newRange
+			} else {
+				lastActive = nil
 			}
 		}
 


### PR DESCRIPTION
From what I can tell, there seems to be an implicit assumption that there will always be an "active" window. This is not the case, at least on windows (you could have everything minimized for example).

This fixes the issue in a quick and dirty way by making sure window returned from the map for the "active" window actually exists before trying to use the pointer.