### PR TITLE
Linux: dynamically detect dependencies and list package names

### DIFF
--- a/linux.go
+++ b/linux.go
@@ -23,12 +23,39 @@ func NewLinuxTracker() Tracker {
 }
 
 func (t *LinuxTracker) Deps() string {
-	return `Install the following command-line utilities via your package manager (e.g., apt) of choice:
-* xdpyinfo
-* xwininfo
-* xdotool
-* wmctrl
-`
+	var output = "\r\nInstall these following command-line utilities via your package manager (e.g., apt) of choice:\r\n"
+	var depsRequired = false
+	if !verifyCommand("xdpyinfo") {
+		output += "\r\n* xdpyinfo"
+		depsRequired = true
+	}
+	if !verifyCommand("xwininfo") {
+		output += "\r\n* xwininfo"
+		depsRequired = true
+	}
+	if !verifyCommand("xdotool") {
+		output += "\r\n* xdotool"
+		depsRequired = true
+	}
+	if !verifyCommand("wmctrl") {
+		output += "\r\n* wmctrl"
+		depsRequired = true
+	}
+
+	if depsRequired {
+		return output+"\r\n\r\nExample deb/apt install command: apt-get install x11-utils xdotool wmctrl\r\nExample rpm/yum install command: yum install xorg-x11-utils xdotool wmctrl"
+	} else {
+		return `All dependencies already installed.`
+	}
+}
+
+func verifyCommand(file string) bool {
+	var _, err = exec.LookPath(file)
+	if err != nil {
+		return false
+	} else {
+		return true
+	}
 }
 
 func (t *LinuxTracker) Snap() (*Snapshot, error) {

--- a/linux.go
+++ b/linux.go
@@ -43,7 +43,9 @@ func (t *LinuxTracker) Deps() string {
 	}
 
 	if depsRequired {
-		return output+"\r\n\r\nExample deb/apt install command: apt-get install x11-utils xdotool wmctrl\r\nExample rpm/yum install command: yum install xorg-x11-utils xdotool wmctrl"
+		output += "\r\n\r\nExample deb/apt install command: apt-get install x11-utils xdotool wmctrl"
+		output += "\r\nExample rpm/yum install command: yum install xorg-x11-utils xdotool wmctrl"
+		return output
 	} else {
 		return `All dependencies already installed.`
 	}


### PR DESCRIPTION
Fixes #36

This uses LookPath to check for dependency existence and
outputs a list of whichever dependencies are not yet installed.
Also outputs example apt/yum commands.

I don't see any test files or instructions so I'm assuming the testing portion of CONTRIBUTING.md is not applicable. This is the first time I've ever written anything in Go, so some manual verification is probably advised.
