### PR TITLE
Remove "osascript install instructions"

### DIFF
--- a/darwin.go
+++ b/darwin.go
@@ -92,8 +92,6 @@ end repeat
 
 func (t *DarwinTracker) Deps() string {
 	return `
-You will need the osascript command-line utility. You can install it via the Apple developer tools ('xcode-select --install') or npm ('npm install --save osascript').
-
 You will need to enable privileges for "Terminal" in System Preferences > Security & Privacy > Privacy > Accessibility.
 See https://support.apple.com/en-us/HT202802 for details.
 `


### PR DESCRIPTION
osascript is on macs by default. No installation neccessary.

(Also The npm module is a wrapper and doesn't expose a binary)

Cheers

This reverts commit 9da116fee30d1a7546e8c4098eabcb55bb7508a0.
fixes #50