### PR TITLE
Windows: Prevent crash from improper call to GetWindowThreadProcessId

### DIFF
--- a/windows.go
+++ b/windows.go
@@ -56,7 +56,7 @@ func getWindowTitle(window uintptr) string {
 // getWindowID returns the process (thread) id that created the window. Multiple windows can share
 // the same process id.
 func getWindowID(window uintptr) int64 {
-	id, _, _ := procGetWindowThreadProcessId.Call(window)
+	id, _, _ := procGetWindowThreadProcessId.Call(window, 0)
 	return int64(id)
 }
 


### PR DESCRIPTION
GetWindowThreadProcessId is expecting a NULL as the second parameter. If it gets any other value, CGO panics. On my machine (Win10 32-bit), it never gets a NULL unless specifically given a value.