### PR TITLE
show: Fix out of bounds error when few bars need to be shown

### DIFF
--- a/show.go
+++ b/show.go
@@ -96,7 +96,11 @@ func (c *BarChart) OrderedBars() []Bar {
 	}
 	s := sortBars{bars}
 	sort.Sort(s)
-	return s.bars[:numberOfBars]
+	barCount := numberOfBars
+	if len(bars) < barCount {
+		barCount = len(bars)
+	}
+	return s.bars[:barCount]
 }
 
 type sortBars struct {

--- a/windows.go
+++ b/windows.go
@@ -56,7 +56,7 @@ func getWindowTitle(window uintptr) string {
 // getWindowID returns the process (thread) id that created the window. Multiple windows can share
 // the same process id.
 func getWindowID(window uintptr) int64 {
-	id, _, _ := procGetWindowThreadProcessId.Call(window)
+	id, _, _ := procGetWindowThreadProcessId.Call(window, 0)
 	return int64(id)
 }
 

--- a/windows.go
+++ b/windows.go
@@ -56,7 +56,7 @@ func getWindowTitle(window uintptr) string {
 // getWindowID returns the process (thread) id that created the window. Multiple windows can share
 // the same process id.
 func getWindowID(window uintptr) int64 {
-	id, _, _ := procGetWindowThreadProcessId.Call(window, 0)
+	id, _, _ := procGetWindowThreadProcessId.Call(window)
 	return int64(id)
 }
 


### PR DESCRIPTION
numberOfBars is a hard-coded value of 30, and if the slice of bars has fewer than that, the program panics. Commit adds bounds checking to only use numberOfBars when there are more than 30 to display.