### PR TITLE
Windows: Remove extra windows when building snapshots

### DIFF
--- a/windows.go
+++ b/windows.go
@@ -93,6 +93,12 @@ func (t *WindowsTracker) Snap() (snap *Snapshot, err error) {
 		if b != 0 {
 			currentTitle := getWindowTitle(uintptr(hwnd))
 			currentId := getWindowID(uintptr(hwnd))
+			// Skip windows that are in a process where we already have a visible window
+			for _, visibleId := range visible {
+				if currentId == visibleId {
+					return 1
+				}
+			}
 			if !windowsIgnore(currentTitle) {
 				if activeTitle == currentTitle {
 					active = currentId


### PR DESCRIPTION
Windows has a bunch of extra windows associated with processes that can often get chosen over the visible desired window title when graphed. This fixes that by prefering the top-most and visible windows as what they show.