### PR TITLE
Fix generation of wrong slot end times

### DIFF
--- a/show.go
+++ b/show.go
@@ -150,10 +150,10 @@ func NewTimeline(stream *Stream, labelFunc func(*Window) string) *Timeline {
 		{
 			if win := windows[snap.Active]; win != nil {
 				winLabel := labelFunc(win)
-				if lastActive != nil && lastActive.Label == winLabel {
+				if lastActive != nil && lastActive.Label == winLabel && snap.Time.Sub(lastActive.Start).Minutes() < 5 {
 					lastActive.End = snap.Time
 				} else {
-					if lastActive != nil {
+					if lastActive != nil && snap.Time.Sub(lastActive.Start).Minutes() < 5 {
 						lastActive.End = snap.Time
 					}
 					newRange := &Range{Label: winLabel, Start: snap.Time, End: snap.Time}
@@ -166,7 +166,9 @@ func NewTimeline(stream *Stream, labelFunc func(*Window) string) *Timeline {
 		}
 
 		for _, prevRange := range lastVisible {
-			prevRange.End = snap.Time
+			if snap.Time.Sub(prevRange.Start).Minutes() < 5 {
+				prevRange.End = snap.Time
+			}
 		}
 		nextVisible := make(map[string]*Range)
 		for _, v := range snap.Visible {
@@ -185,7 +187,9 @@ func NewTimeline(stream *Stream, labelFunc func(*Window) string) *Timeline {
 		lastVisible = nextVisible
 
 		for _, prevRange := range lastOther {
-			prevRange.End = snap.Time
+			if snap.Time.Sub(prevRange.Start).Minutes() < 5 {
+				prevRange.End = snap.Time
+			}
 		}
 		nextOther := make(map[string]*Range)
 		for _, win := range snap.Windows {

--- a/show.go
+++ b/show.go
@@ -150,7 +150,7 @@ func NewTimeline(stream *Stream, labelFunc func(*Window) string) *Timeline {
 		{
 			if win := windows[snap.Active]; win != nil {
 				winLabel := labelFunc(win)
-				if lastActive != nil && lastActive.Label == winLabel && snap.Time.Sub(lastActive.Start).Minutes() < 5 {
+				if lastActive != nil && lastActive.Label == winLabel {
 					lastActive.End = snap.Time
 				} else {
 					if lastActive != nil && snap.Time.Sub(lastActive.Start).Minutes() < 5 {


### PR DESCRIPTION
Previously, the time of the next slot always became the end time of the
previous one.
This created huge slots when the computer was on standby for some amount
of time, falsely logging the last program for a much longer time than it
was used.